### PR TITLE
feat: change `delete` and `search` method signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,28 @@ $ npm install --save @truck/singly-linked-list
 
 Build a new _Singly Linked-List_.
 
-### _Methods >_ `delete(value: any, comparator?: (a: any, b: any) => boolean): boolean` (_O(n)_)
+### _Methods >_ `delete(value: any): boolean` (_O(n)_)
 
-Deletes a value from the _Singly Linked-List_. The optional `comparator` method can be passed-in,
-otherwise a default `===` comparator is used.
+Deletes a value from the _Singly Linked-List_. The default `===` comparator is used.
+
+### _Methods >_ `delete(comparator: (value: any) => boolean): boolean` (_O(n)_)
+
+Deletes a value from the _Singly Linked-List_. Uses the `comparator` to determine whether the
+`value` should be deleted.
 
 ### _Methods >_ `insert(value: any): void` (_O(1)_)
 
 Inserts a value at the beginning of the _Singly Linked-List_.
 
-### _Methods >_ `search(value: any, comparator?: (a: any, b: any) => boolean): Node` (_O(n)_)
+### _Methods >_ `search(value: any): Node|undefined` (_O(n)_)
 
-Returns the first `value` in the _Singly Linked-List_ that matches. The optional `comparator` method
-can be passed-in, otherwise a default `===` comparator is used.
+Returns the first `value` in the _Singly Linked-List_ that matches `value`. The default `===`
+comparator is used.
+
+### _Methods >_ `search(comparator: (value: any) => boolean): Node|undefined` (_O(n)_)
+
+Returns the first `value` in the _Singly Linked-List_ that matches. Uses `comparator` to determine
+whether the `value` matches.
 
 ### _Methods >_ `toArray(): any[]` (_O(n)_)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3874,14 +3874,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3896,20 +3894,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4026,8 +4021,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4039,7 +4033,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4054,7 +4047,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4062,14 +4054,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4088,7 +4078,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4169,8 +4158,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4182,7 +4170,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4304,7 +4291,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6868,6 +6854,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "lodash.isfunction": "^3.0.9"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
+import isFunction from 'lodash.isfunction';
+
 import Node from './node';
 
-const defaultComparator = (a, b) => a === b;
+const defaultComparator = a => b => a === b;
 
 class SinglyLinkedList {
   constructor() {
@@ -12,12 +14,13 @@ class SinglyLinkedList {
     return this.listSize;
   }
 
-  delete(value, comparator = defaultComparator) {
+  delete(value) {
+    const comparator = isFunction(value) ? value : defaultComparator(value);
     let current = this.head;
     if (!current) {
       return false;
     }
-    if (comparator(current.value, value)) {
+    if (comparator(current.value)) {
       this.head = this.head.next;
       this.listSize -= 1;
       return true;
@@ -25,7 +28,7 @@ class SinglyLinkedList {
     while (current) {
       const { next } = current;
       if (next) {
-        if (comparator(next.value, value)) {
+        if (comparator(next.value)) {
           current.next = next.next;
           this.listSize -= 1;
           return true;
@@ -45,10 +48,11 @@ class SinglyLinkedList {
     this.listSize += 1;
   }
 
-  search(value, comparator = defaultComparator) {
+  search(value) {
+    const comparator = isFunction(value) ? value : defaultComparator(value);
     let current = this.head;
     while (current) {
-      if (comparator(current.value, value)) {
+      if (comparator(current.value)) {
         return current;
       }
       current = current.next;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -82,7 +82,7 @@ describe('.delete()', () => {
     singlyLinkedList.insert({ name: 1 });
     singlyLinkedList.insert({ name: 2 });
     singlyLinkedList.insert({ name: 3 });
-    singlyLinkedList.delete({ name: 3 }, ({ name: nameA }, { name: nameB }) => nameA === nameB);
+    singlyLinkedList.delete(value => value.name === 3);
     const actual = singlyLinkedList.length;
 
     expect(actual).toBe(expected);
@@ -123,10 +123,9 @@ describe('.search()', () => {
   });
 
   test('Finds an object with a custom comparator', () => {
-    const comparator = ({ name: nameA }, { name: nameB }) => nameA === nameB;
     const expected = { name: 3 };
 
-    const actual = singlyLinkedList.search({ name: 3 }, comparator).value;
+    const actual = singlyLinkedList.search(value => value.name === 3).value;
 
     expect(actual).toEqual(expected);
   });


### PR DESCRIPTION
value can now be a value or a comparator method

BREAKING CHANGE: `delete` and `search` method signatures changed
each now only accept a single parameter instead of two